### PR TITLE
fix: Don't steal across scopes

### DIFF
--- a/pytest_cdist/plugin.py
+++ b/pytest_cdist/plugin.py
@@ -238,12 +238,6 @@ def pytest_collection_modifyitems(
 
     groups = _partition_list(items, cdist_config.total_groups)
 
-    if cdist_config.justify_items_strategy != "none":
-        groups = _justify_items(groups, strategy=cdist_config.justify_items_strategy)
-
-    if os.getenv("PYTEST_XDIST_WORKER"):
-        groups = _justify_xdist_groups(groups)
-
     if cdist_config.group_steal is not None:
         target_group, amount_to_steal = cdist_config.group_steal
         groups = _distribute_with_bias(
@@ -251,6 +245,12 @@ def pytest_collection_modifyitems(
             target=target_group,
             bias=amount_to_steal,
         )
+
+    if cdist_config.justify_items_strategy != "none":
+        groups = _justify_items(groups, strategy=cdist_config.justify_items_strategy)
+
+    if os.getenv("PYTEST_XDIST_WORKER"):
+        groups = _justify_xdist_groups(groups)
 
     new_items = groups.pop(cdist_config.current_group)
     deselect = [item for group in groups for item in group]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -209,6 +209,32 @@ def test_steal(
     result.assert_outcomes(passed=3, deselected=1)
 
 
+def test_steal_with_justify(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile("""
+    class TestFoo:
+        def test_one(self):
+            assert True
+
+        def test_two(self):
+            assert True
+    """)
+
+    # Stealing should never break the scope
+    result = pytester.runpytest(
+        "--cdist-group=1/2",
+        "--cdist-justify-items=scope",
+        "--cdist-group-steal=2:60",
+    )
+    result.assert_outcomes(passed=2, deselected=0)
+
+    result = pytester.runpytest(
+        "--cdist-group=2/2",
+        "--cdist-justify-items=scope",
+        "--cdist-group-steal=2:60",
+    )
+    result.assert_outcomes(passed=0, deselected=2)
+
+
 def test_raises_for_invalid_randomly_cfg(pytester: pytest.Pytester) -> None:
     pytester.makeini("")
 


### PR DESCRIPTION
Fix a bug that would steal across scopes defined in `justify-items`.