### PR TITLE
Fix `pytest --help` string formatting issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-cdist"
-version = "0.5.0"
+version = "0.5.1"
 description = "A pytest plugin to split your test suite into multiple parts"
 authors = [
   { name = "Janek Nouvertné", email = "provinzkraut@posteo.de" },

--- a/pytest_cdist/plugin.py
+++ b/pytest_cdist/plugin.py
@@ -254,7 +254,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store",
         default=None,
         help="make a group steal a percentage of items from other groups. '1:30' would "
-        "make group 1 steal 30% of items from all other groups",
+        "make group 1 steal 30%% of items from all other groups",
     )
 
     parser.addini("cdist-justify-items", help="justify items strategy", default="none")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -382,3 +382,8 @@ def test_randomly_with_dont_reorganize(pytester: pytest.Pytester, i: int) -> Non
         "--cdist-group=2/2", "--randomly-dont-reorganize"
     )
     result.assert_outcomes(passed=0, failed=1, deselected=2)
+
+
+# check for https://github.com/provinzkraut/pytest-cdist/issues/12
+def test_help(pytester: pytest.Pytester) -> None:
+    pytester.runpytest("--help")

--- a/uv.lock
+++ b/uv.lock
@@ -221,7 +221,7 @@ wheels = [
 
 [[package]]
 name = "pytest-cdist"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "pytest" },


### PR DESCRIPTION
Escape `%` signs in help text so argparse does not trip over them.

Closes #12.